### PR TITLE
Enable raw data output

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ Out[15]: List(<init>, toByte, toShort, toChar, toInt, toLong, toFloat, toDouble,
 unary_+, unary_-, +, <<, >>>, >>, ==, !=, <, <=, >, >=, |, &, ^, -, *, /, %, getClass)
 ```
 
+## HTML and raw output
+
+IPython notebook runs in web browser. It makes possible to use HTML output to render images or whatever you can imagine.
+
+```
+In [1]: raw_output("text/plain", "<i>italic</i>")
+```
+Out[1]: `<i>italic</i>`
+
+```
+In [2]: raw_output("text/html", "<i>italic</i>")
+```
+Out[2]: _italic_
+
+
+```
+In [2]: raw_output("image/png", "BASE64_PNG_DATA")
+```
+Out[2]: <img src='http://blog.concretesolutions.com.br/wp-content/uploads/2012/05/scala_logo.png' />
+
 ## Magics
 
 IScala supports magic commands similarly to IPython, but the set of magics is

--- a/src/main/scala/Msg.scala
+++ b/src/main/scala/Msg.scala
@@ -50,6 +50,8 @@ object MsgType extends Enumeration {
         input_reply = Value
 }
 
+class RawMsg(val mime: MIME, val data: String)
+
 sealed trait Content
 sealed trait FromIPython extends Content
 sealed trait ToIPython extends Content


### PR DESCRIPTION
Raw data output is necessary for showing generated images inside the notebook. This little change adds this ability by simple virtual functions.
