### PR TITLE
Obtain `baseDir` through more portable means.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -213,7 +213,7 @@ object IScalaBuild extends Build {
                 }
             },
             userScripts := {
-                val baseDir = "$(dirname $(dirname $(readlink -f $0)))"
+                val baseDir = "$(cd \"$(dirname $(dirname \"$0\"))\" && pwd)"
                 val jarName = {
                     import SbtAssembly.AssemblyKeys.{assembly,jarName=>jar}
                     (jar in assembly).value


### PR DESCRIPTION
`readlink -f` does not work on OS X.

This commit replaces the use of `readlink -f` with something more
portable.

While this approach may not always fully resolve symlinks, it should be
fine since java seems to resolve symlinks.
