### PR TITLE
Warn development has stopped, point to Almond

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 [![Build Status][travis]](https://travis-ci.org/mattpap/IScala)
 
+## Warning
+
+**Development of IScala has stopped.**
+
+See **Almond** for a Scala kernel for Jupyter that is actively being developed.
+
+- Almond home: http://almond-sh.github.io/almond/stable
+- Almond repo: https://github.com/almond-sh/almond
+- Almond install: http://almond-sh.github.io/almond/stable/docs/quick-start-install
+- Almond versions: http://almond-sh.github.io/almond/stable/docs/install-versions
+
 ## Requirements
 
 * [IPython](http://ipython.org/ipython-doc/stable/install/install.html) 1.0+


### PR DESCRIPTION
Add a clear warning at the top of the readme indicating that
development of IScala has stopped, and point to Almond for
a currently maintained replacement.